### PR TITLE
Implement in-memory AllenNLP integration

### DIFF
--- a/optuna/integration/allennlp/_executor.py
+++ b/optuna/integration/allennlp/_executor.py
@@ -9,14 +9,8 @@ from typing import Union
 import optuna
 from optuna._experimental import experimental
 from optuna._imports import try_import
-from optuna.integration.allennlp._environment import _environment_variables
-from optuna.integration.allennlp._variables import _MONITOR
-from optuna.integration.allennlp._variables import _PREFIX
-from optuna.integration.allennlp._variables import _PRUNER_CLASS
-from optuna.integration.allennlp._variables import _PRUNER_KEYS
-from optuna.integration.allennlp._variables import _STORAGE_NAME
-from optuna.integration.allennlp._variables import _STUDY_NAME
-from optuna.integration.allennlp._variables import _TRIAL_ID
+from optuna.integration.allennlp.environment import _environment_variables
+import optuna.integration.allennlp.train
 
 
 with try_import() as _imports:
@@ -29,44 +23,6 @@ with try_import() as _imports:
 # the environment that builds the documentation.
 if _imports.is_successful():
     import _jsonnet
-
-
-def _fetch_pruner_config(trial: optuna.Trial) -> Dict[str, Any]:
-    pruner = trial.study.pruner
-    kwargs: Dict[str, Any] = {}
-
-    if isinstance(pruner, optuna.pruners.HyperbandPruner):
-        kwargs["min_resource"] = pruner._min_resource
-        kwargs["max_resource"] = pruner._max_resource
-        kwargs["reduction_factor"] = pruner._reduction_factor
-
-    elif isinstance(pruner, optuna.pruners.MedianPruner):
-        kwargs["n_startup_trials"] = pruner._n_startup_trials
-        kwargs["n_warmup_steps"] = pruner._n_warmup_steps
-        kwargs["interval_steps"] = pruner._interval_steps
-
-    elif isinstance(pruner, optuna.pruners.PercentilePruner):
-        kwargs["percentile"] = pruner._percentile
-        kwargs["n_startup_trials"] = pruner._n_startup_trials
-        kwargs["n_warmup_steps"] = pruner._n_warmup_steps
-        kwargs["interval_steps"] = pruner._interval_steps
-
-    elif isinstance(pruner, optuna.pruners.SuccessiveHalvingPruner):
-        kwargs["min_resource"] = pruner._min_resource
-        kwargs["reduction_factor"] = pruner._reduction_factor
-        kwargs["min_early_stopping_rate"] = pruner._min_early_stopping_rate
-
-    elif isinstance(pruner, optuna.pruners.ThresholdPruner):
-        kwargs["lower"] = pruner._lower
-        kwargs["upper"] = pruner._upper
-        kwargs["n_warmup_steps"] = pruner._n_warmup_steps
-        kwargs["interval_steps"] = pruner._interval_steps
-    elif isinstance(pruner, optuna.pruners.NopPruner):
-        pass
-    else:
-        raise ValueError("Unsupported pruner is specified: {}".format(type(pruner)))
-
-    return kwargs
 
 
 @experimental("1.4.0")
@@ -132,6 +88,7 @@ class AllenNLPExecutor(object):
     ):
         _imports.check()
 
+        self._trial = trial
         self._params = trial.params
         self._config_file = config_file
         self._serialization_dir = serialization_dir
@@ -146,37 +103,6 @@ class AllenNLPExecutor(object):
         else:
             self._include_package = include_package
 
-        storage = trial.study._storage
-
-        if isinstance(storage, optuna.storages.RDBStorage):
-            url = storage.url
-        elif isinstance(storage, optuna.storages.RedisStorage):
-            url = storage._url
-        elif isinstance(storage, optuna.storages._CachedStorage):
-            assert isinstance(storage._backend, optuna.storages.RDBStorage)
-            url = storage._backend.url
-        else:
-            url = ""
-
-        pruner_params = _fetch_pruner_config(trial)
-        pruner_params = {
-            "{}_{}".format(_PREFIX, key): repr(value) for key, value in pruner_params.items()
-        }
-
-        system_attrs = {
-            _STUDY_NAME: trial.study.study_name,
-            _TRIAL_ID: str(trial._trial_id),
-            _STORAGE_NAME: url,
-            _MONITOR: metrics,
-            _PRUNER_KEYS: ",".join(pruner_params.keys()),
-        }
-
-        if trial.study.pruner is not None:
-            system_attrs[_PRUNER_CLASS] = type(trial.study.pruner).__name__
-
-        system_attrs.update(pruner_params)
-        self._system_attrs = system_attrs
-
     def _build_params(self) -> Dict[str, Any]:
         """Create a dict of params for AllenNLP.
 
@@ -187,12 +113,7 @@ class AllenNLPExecutor(object):
         """
         params = _environment_variables()
         params.update({key: str(value) for key, value in self._params.items()})
-        params.update(self._system_attrs)
         return json.loads(_jsonnet.evaluate_file(self._config_file, ext_vars=params))
-
-    def _set_environment_variables(self) -> None:
-        for key, value in self._system_attrs.items():
-            os.environ[key] = value
 
     def run(self) -> float:
         """Train a model using AllenNLP."""
@@ -210,14 +131,14 @@ class AllenNLPExecutor(object):
         allennlp.common.cached_transformers._model_cache.clear()
         allennlp.common.cached_transformers._tokenizer_cache.clear()
 
-        self._set_environment_variables()
         params = allennlp.common.params.Params(self._build_params())
-        allennlp.commands.train.train_model(
+        optuna.integration.allennlp.train.train_model_with_optuna(
             params=params,
             serialization_dir=self._serialization_dir,
             file_friendly_logging=self._file_friendly_logging,
             force=self._force,
             include_package=self._include_package,
+            trial=self._trial,
         )
         metrics = json.load(open(os.path.join(self._serialization_dir, "metrics.json")))
         return metrics[self._metrics]

--- a/optuna/integration/allennlp/_pruner.py
+++ b/optuna/integration/allennlp/_pruner.py
@@ -1,15 +1,10 @@
-import os
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import Optional
-from typing import Union
 
 from packaging import version
 
 import optuna
-from optuna import load_study
-from optuna import Trial
 from optuna._experimental import experimental
 from optuna._imports import try_import
 from optuna.integration.allennlp._variables import _MONITOR
@@ -53,57 +48,6 @@ else:
             return wrapper
 
 
-def _create_pruner() -> Optional[optuna.pruners.BasePruner]:
-    """Restore a pruner which is defined in `create_study`.
-
-    `AllenNLPPruningCallback` is launched as a sub-process of
-    a main script that defines search spaces.
-    An instance cannot be passed directly from the parent process
-    to its sub-process. For this reason, we set information about
-    pruner as environment variables and load them and
-    re-create the same pruner in `AllenNLPPruningCallback`.
-
-    """
-    pruner_class = os.getenv(_PRUNER_CLASS)
-    if pruner_class is None:
-        return None
-
-    pruner_params = _get_environment_variables_for_pruner()
-    pruner = getattr(optuna.pruners, pruner_class, None)
-
-    if pruner is None:
-        return None
-
-    return pruner(**pruner_params)
-
-
-def _get_environment_variables_for_trial() -> Dict[str, Optional[str]]:
-    return {
-        "study_name": os.getenv(_STUDY_NAME),
-        "trial_id": os.getenv(_TRIAL_ID),
-        "storage": os.getenv(_STORAGE_NAME),
-        "monitor": os.getenv(_MONITOR),
-    }
-
-
-def _get_environment_variables_for_pruner() -> Dict[str, Optional[Union[str, int, float, bool]]]:
-    keys = os.getenv(_PRUNER_KEYS)
-
-    # keys would be empty when `_PRUNER_CLASS` is `NopPruner`
-    if keys is None or keys == "":
-        return {}
-
-    kwargs = {}
-    for key in keys.split(","):
-        key_without_prefix = key.replace("{}_".format(_PREFIX), "")
-        value = os.getenv(key)
-        if value is None:
-            raise ValueError(f"{key} is not found in environment variables.")
-        kwargs[key_without_prefix] = eval(value)
-
-    return kwargs
-
-
 @experimental("2.0.0")
 @TrainerCallback.register("optuna_pruner")
 class AllenNLPPruningCallback(TrainerCallback):
@@ -143,8 +87,8 @@ class AllenNLPPruningCallback(TrainerCallback):
 
     def __init__(
         self,
-        trial: Optional[optuna.trial.Trial] = None,
-        monitor: Optional[str] = None,
+        trial: optuna.trial.Trial,
+        monitor: str,
     ):
         _imports.check()
 
@@ -155,47 +99,8 @@ class AllenNLPPruningCallback(TrainerCallback):
                 "please install Optuna v2.5.0 by executing `pip install 'optuna==2.5.0'`."
             )
 
-        # When `AllenNLPPruningCallback` is instantiated in Python script,
-        # trial and monitor should not be `None`.
-        if trial is not None and monitor is not None:
-            self._trial = trial
-            self._monitor = monitor
-
-        # When `AllenNLPPruningCallback` is used with `AllenNLPExecutor`,
-        # `trial` and `monitor` would be None. `AllenNLPExecutor` sets information
-        # for a study name, trial id, monitor, and storage in environment variables.
-        else:
-            environment_variables = _get_environment_variables_for_trial()
-            study_name = environment_variables["study_name"]
-            trial_id = environment_variables["trial_id"]
-            monitor = environment_variables["monitor"]
-            storage = environment_variables["storage"]
-
-            if study_name is None or trial_id is None or monitor is None or storage is None:
-                message = (
-                    "Fail to load study. Perhaps you attempt to use `AllenNLPPruningCallback`"
-                    " without `AllenNLPExecutor`. If you want to use a callback"
-                    " without an executor, you have to instantiate a callback with"
-                    "`trial` and `monitor. Please see the Optuna example: https://github.com/"
-                    "optuna/optuna-examples/tree/main/allennlp/allennlp_simple.py."
-                )
-                raise RuntimeError(message)
-
-            else:
-                # If `stoage` is empty despite `study_name`, `trial_id`,
-                # and `monitor` are not `None`, users attempt to use `AllenNLPPruningCallback`
-                # with `AllenNLPExecutor` and in-memory storage.
-                # `AllenNLPruningCallback` needs RDB or Redis storages to work.
-                if storage == "":
-                    message = (
-                        "If you want to use AllenNLPExecutor and AllenNLPPruningCallback,"
-                        " you have to use RDB or Redis storage."
-                    )
-                    raise RuntimeError(message)
-
-                study = load_study(study_name, storage, pruner=_create_pruner())
-                self._trial = Trial(study, int(trial_id))
-                self._monitor = monitor
+        self._trial = trial
+        self._monitor = monitor
 
     def on_epoch(
         self,

--- a/optuna/integration/allennlp/train.py
+++ b/optuna/integration/allennlp/train.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 
 def train_model_with_optuna(
-    trial: Trial,
     params: Params,
     serialization_dir: Union[str, PathLike],
     recover: bool = False,
@@ -40,6 +39,7 @@ def train_model_with_optuna(
     include_package: List[str] = None,
     dry_run: bool = False,
     file_friendly_logging: bool = False,
+    trial: Trial = None,
 ) -> Optional[Model]:
     """
     Trains the model specified in the given [`Params`](../common/params.md#params) object, using the data
@@ -89,13 +89,13 @@ def train_model_with_optuna(
     # one cuda device, we just run a single training process.
     if distributed_params is None:
         model = _train_worker_with_optuna(
-            trial=trial,
             process_rank=0,
             params=params,
             serialization_dir=serialization_dir,
             include_package=include_package,
             dry_run=dry_run,
             file_friendly_logging=file_friendly_logging,
+            trial=trial,
         )
 
         if not dry_run:
@@ -188,7 +188,6 @@ def train_model_with_optuna(
 
 
 def _train_worker_with_optuna(
-    trial: Trial,
     process_rank: int,
     params: Params,
     serialization_dir: Union[str, PathLike],
@@ -201,6 +200,7 @@ def _train_worker_with_optuna(
     distributed_device_ids: List[int] = None,
     file_friendly_logging: bool = False,
     include_in_archive: List[str] = None,
+    trial: Trial = None,
 ) -> Optional[Model]:
     """
     Helper to train the configured model/experiment. In distributed mode, this is spawned as a

--- a/optuna/integration/allennlp/train.py
+++ b/optuna/integration/allennlp/train.py
@@ -1,0 +1,353 @@
+"""
+The `train` subcommand can be used to train a model.
+It requires a configuration file and a directory in
+which to write the results.
+"""
+
+import logging
+import os
+from os import PathLike
+from typing import List, Optional, Union
+
+from optuna import Trial
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from allennlp.commands.train import TrainModel
+from allennlp.common import Params
+from allennlp.common.checks import check_for_gpu, ConfigurationError
+from allennlp.common.meta import Meta, META_NAME
+from allennlp.common import logging as common_logging
+from allennlp.common import util as common_util
+from allennlp.common.plugins import import_plugins
+from allennlp.data import Vocabulary
+from allennlp.models.archival import archive_model, CONFIG_NAME, verify_include_in_archive
+from allennlp.models.model import _DEFAULT_WEIGHTS, Model
+from allennlp.training import util as training_util
+
+logger = logging.getLogger(__name__)
+
+
+def train_model_with_optuna(
+    trial: Trial,
+    params: Params,
+    serialization_dir: Union[str, PathLike],
+    recover: bool = False,
+    force: bool = False,
+    node_rank: int = 0,
+    include_package: List[str] = None,
+    dry_run: bool = False,
+    file_friendly_logging: bool = False,
+) -> Optional[Model]:
+    """
+    Trains the model specified in the given [`Params`](../common/params.md#params) object, using the data
+    and training parameters also specified in that object, and saves the results in `serialization_dir`.
+
+    # Parameters
+
+    params : `Params`
+        A parameter object specifying an AllenNLP Experiment.
+    serialization_dir : `str`
+        The directory in which to save results and logs.
+    recover : `bool`, optional (default=`False`)
+        If `True`, we will try to recover a training run from an existing serialization
+        directory.  This is only intended for use when something actually crashed during the middle
+        of a run.  For continuing training a model on new data, see `Model.from_archive`.
+    force : `bool`, optional (default=`False`)
+        If `True`, we will overwrite the serialization directory if it already exists.
+    node_rank : `int`, optional
+        Rank of the current node in distributed training
+    include_package : `List[str]`, optional
+        In distributed mode, extra packages mentioned will be imported in trainer workers.
+    dry_run : `bool`, optional (default=`False`)
+        Do not train a model, but create a vocabulary, show dataset statistics and other training
+        information.
+    file_friendly_logging : `bool`, optional (default=`False`)
+        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
+
+    # Returns
+
+    best_model : `Optional[Model]`
+        The model with the best epoch weights or `None` if in dry run.
+    """
+    common_logging.FILE_FRIENDLY_LOGGING = file_friendly_logging
+
+    training_util.create_serialization_dir(params, serialization_dir, recover, force)
+    params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
+
+    meta = Meta.new()
+    meta.to_file(os.path.join(serialization_dir, META_NAME))
+
+    include_in_archive = params.pop("include_in_archive", None)
+    verify_include_in_archive(include_in_archive)
+
+    distributed_params = params.params.pop("distributed", None)
+    # If distributed isn't in the config and the config contains strictly
+    # one cuda device, we just run a single training process.
+    if distributed_params is None:
+        model = _train_worker_with_optuna(
+            trial=trial,
+            process_rank=0,
+            params=params,
+            serialization_dir=serialization_dir,
+            include_package=include_package,
+            dry_run=dry_run,
+            file_friendly_logging=file_friendly_logging,
+        )
+
+        if not dry_run:
+            archive_model(serialization_dir, include_in_archive=include_in_archive)
+        return model
+
+    # Otherwise, we are running multiple processes for training.
+    else:
+        common_logging.prepare_global_logging(
+            serialization_dir,
+            rank=0,
+            world_size=1,
+        )
+
+        # We are careful here so that we can raise a good error if someone
+        # passed the wrong thing - cuda_devices are required.
+        device_ids = distributed_params.pop("cuda_devices", None)
+        multi_device = isinstance(device_ids, list) and len(device_ids) > 1
+        num_nodes = distributed_params.pop("num_nodes", 1)
+
+        if not (multi_device or num_nodes > 1):
+            raise ConfigurationError(
+                "Multiple cuda devices/nodes need to be configured to run distributed training."
+            )
+        check_for_gpu(device_ids)
+
+        primary_addr = distributed_params.pop("primary_address", "127.0.0.1")
+        if primary_addr in ("127.0.0.1", "0.0.0.0", "localhost"):
+            # If running locally, we can automatically find an open port if one is not specified.
+            primary_port = (
+                distributed_params.pop("primary_port", None) or common_util.find_open_port()
+            )
+        else:
+            # Otherwise we require that the port be specified.
+            primary_port = distributed_params.pop("primary_port")
+
+        num_procs = len(device_ids)
+        world_size = num_nodes * num_procs
+
+        # Creating `Vocabulary` objects from workers could be problematic since
+        # the data loaders in each worker will yield only `rank` specific
+        # instances. Hence it is safe to construct the vocabulary and write it
+        # to disk before initializing the distributed context. The workers will
+        # load the vocabulary from the path specified.
+        vocab_dir = os.path.join(serialization_dir, "vocabulary")
+        if recover:
+            vocab = Vocabulary.from_files(vocab_dir)
+        else:
+            vocab = training_util.make_vocab_from_params(
+                params.duplicate(), serialization_dir, print_statistics=dry_run
+            )
+        params["vocabulary"] = {
+            "type": "from_files",
+            "directory": vocab_dir,
+            "padding_token": vocab._padding_token,
+            "oov_token": vocab._oov_token,
+        }
+
+        logging.info(
+            "Switching to distributed training mode since multiple GPUs are configured | "
+            f"Primary is at: {primary_addr}:{primary_port} | Rank of this node: {node_rank} | "
+            f"Number of workers in this node: {num_procs} | Number of nodes: {num_nodes} | "
+            f"World size: {world_size}"
+        )
+
+        mp.spawn(
+            _train_worker_with_optuna,
+            args=(
+                trial,
+                params.duplicate(),
+                serialization_dir,
+                include_package,
+                dry_run,
+                node_rank,
+                primary_addr,
+                primary_port,
+                world_size,
+                device_ids,
+                file_friendly_logging,
+                include_in_archive,
+            ),
+            nprocs=num_procs,
+        )
+        if dry_run:
+            return None
+        else:
+            archive_model(serialization_dir, include_in_archive=include_in_archive)
+            model = Model.load(params, serialization_dir)
+            return model
+
+
+def _train_worker_with_optuna(
+    trial: Trial,
+    process_rank: int,
+    params: Params,
+    serialization_dir: Union[str, PathLike],
+    include_package: List[str] = None,
+    dry_run: bool = False,
+    node_rank: int = 0,
+    primary_addr: str = "127.0.0.1",
+    primary_port: int = 29500,
+    world_size: int = 1,
+    distributed_device_ids: List[int] = None,
+    file_friendly_logging: bool = False,
+    include_in_archive: List[str] = None,
+) -> Optional[Model]:
+    """
+    Helper to train the configured model/experiment. In distributed mode, this is spawned as a
+    worker process. In a single GPU experiment, this returns the `Model` object and in distributed
+    training, nothing is returned.
+
+    # Parameters
+
+    process_rank : `int`
+        The process index that is initialized using the GPU device id.
+    params : `Params`
+        A parameter object specifying an AllenNLP Experiment.
+    serialization_dir : `str`
+        The directory in which to save results and logs.
+    include_package : `List[str]`, optional
+        In distributed mode, since this function would have been spawned as a separate process,
+        the extra imports need to be done again. NOTE: This does not have any effect in single
+        GPU training.
+    dry_run : `bool`, optional (default=`False`)
+        Do not train a model, but create a vocabulary, show dataset statistics and other training
+        information.
+    node_rank : `int`, optional
+        Rank of the node.
+    primary_addr : `str`, optional (default=`"127.0.0.1"`)
+        Address of the primary node for distributed training.
+    primary_port : `str`, optional (default=`"29500"`)
+        Port of the primary node for distributed training.
+    world_size : `int`, optional
+        The number of processes involved in distributed training.
+    distributed_device_ids: `List[str]`, optional
+        IDs of the devices used involved in distributed training.
+    file_friendly_logging : `bool`, optional (default=`False`)
+        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
+    include_in_archive : `List[str]`, optional
+        Paths relative to `serialization_dir` that should be archived in addition to the default ones.
+
+    # Returns
+
+    best_model : `Optional[Model]`
+        The model with the best epoch weights or `None` if in distributed training or in dry run.
+    """
+    common_logging.FILE_FRIENDLY_LOGGING = file_friendly_logging
+
+    common_logging.prepare_global_logging(
+        serialization_dir,
+        rank=process_rank,
+        world_size=world_size,
+    )
+    common_util.prepare_environment(params)
+
+    distributed = world_size > 1
+
+    primary = process_rank == 0
+
+    include_package = include_package or []
+
+    if distributed:
+        assert distributed_device_ids is not None
+
+        # Since the worker is spawned and not forked, the extra imports need to be done again.
+        # Both the ones from the plugins and the ones from `include_package`.
+        import_plugins()
+        for package_name in include_package:
+            common_util.import_module_and_submodules(package_name)
+
+        num_procs_per_node = len(distributed_device_ids)
+        # The Unique identifier of the worker process among all the processes in the
+        # distributed training group is computed here. This is used while initializing
+        # the process group using `init_process_group`
+        global_rank = node_rank * num_procs_per_node + process_rank
+
+        # Number of processes per node is useful to know if a process
+        # is a primary in the local node(node in which it is running)
+        os.environ["ALLENNLP_PROCS_PER_NODE"] = str(num_procs_per_node)
+
+        # In distributed training, the configured device is always going to be a list.
+        # The corresponding gpu id for the particular worker is obtained by picking the id
+        # from the device list with the rank as index
+        gpu_id = distributed_device_ids[process_rank]  # type: ignore
+
+        # Till now, "cuda_device" might not be set in the trainer params.
+        # But a worker trainer needs to only know about its specific GPU id.
+        params["trainer"]["cuda_device"] = gpu_id
+        params["trainer"]["world_size"] = world_size
+        params["trainer"]["distributed"] = True
+
+        if gpu_id >= 0:
+            torch.cuda.set_device(int(gpu_id))
+            dist.init_process_group(
+                backend="nccl",
+                init_method=f"tcp://{primary_addr}:{primary_port}",
+                world_size=world_size,
+                rank=global_rank,
+            )
+        else:
+            dist.init_process_group(
+                backend="gloo",
+                init_method=f"tcp://{primary_addr}:{primary_port}",
+                world_size=world_size,
+                rank=global_rank,
+            )
+        logging.info(
+            f"Process group of world size {world_size} initialized "
+            f"for distributed training in worker {global_rank}"
+        )
+
+    train_loop = TrainModel.from_params(
+        params=params,
+        serialization_dir=serialization_dir,
+        local_rank=process_rank,
+        trial=trial,
+    )
+
+    if dry_run:
+        return None
+
+    try:
+        if distributed:  # let the setup get ready for all the workers
+            dist.barrier()
+
+        metrics = train_loop.run()
+    except KeyboardInterrupt:
+        # if we have completed an epoch, try to create a model archive.
+        if primary and os.path.exists(os.path.join(serialization_dir, _DEFAULT_WEIGHTS)):
+            best_weights_path = train_loop.trainer.get_best_weights_path()
+            if best_weights_path is None:
+                logging.info(
+                    "Training interrupted by the user, and no best model has been saved. "
+                    "No model archive created."
+                )
+            else:
+                logging.info(
+                    "Training interrupted by the user. Attempting to create "
+                    "a model archive using the current best epoch weights."
+                )
+                archive_model(
+                    serialization_dir,
+                    weights=best_weights_path,
+                    include_in_archive=include_in_archive,
+                )
+        raise
+
+    if primary:
+        train_loop.finish(metrics)
+
+    if not distributed:
+        return train_loop.model
+
+    return None

--- a/tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet
+++ b/tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet
@@ -60,6 +60,7 @@ local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
     callbacks: [
       {
         type: 'optuna_pruner',
+        monitor: 'best_validation_loss',
       }
     ],
   },

--- a/tests/integration_tests/allennlp_tests/test_allennlp.py
+++ b/tests/integration_tests/allennlp_tests/test_allennlp.py
@@ -20,7 +20,6 @@ import torch.optim
 
 import optuna
 from optuna.integration.allennlp import AllenNLPPruningCallback
-from optuna.integration.allennlp._pruner import _create_pruner
 from optuna.testing.integration import DeterministicPruner
 
 
@@ -191,11 +190,12 @@ def test_allennlp_executor_with_options() -> None:
         )
 
         # ``executor.run`` loads ``metrics.json``
-        # after running ``allennlp.commands.train.train_model``.
+        # after running ``optuna.integration.allennlp.train.train_model_with_optuna``.
         with open(os.path.join(executor._serialization_dir, "metrics.json"), "w") as fout:
             json.dump({executor._metrics: 1.0}, fout)
 
-        with mock.patch("allennlp.commands.train.train_model", return_value=None) as mock_obj:
+        patch_target = "optuna.integration.allennlp.train.train_model_with_optuna"
+        with mock.patch(patch_target, return_value=None) as mock_obj:
             executor.run()
             assert mock_obj.call_args[1]["force"]
             assert mock_obj.call_args[1]["file_friendly_logging"]
@@ -310,58 +310,7 @@ def test_allennlp_pruning_callback() -> None:
         assert study.trials[0].value == 1.0
 
 
-def test_allennlp_pruning_callback_with_invalid_storage() -> None:
-    input_config_file = (
-        "tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet"
-    )
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-
-        def objective(trial: optuna.Trial) -> float:
-            trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-            trial.suggest_float("DROPOUT", 0.0, 0.5)
-            executor = optuna.integration.AllenNLPExecutor(trial, input_config_file, tmp_dir)
-            return executor.run()
-
-        study = optuna.create_study(
-            direction="maximize",
-            pruner=optuna.pruners.HyperbandPruner(),
-            storage=None,
-        )
-
-        with pytest.raises(RuntimeError):
-            study.optimize(objective)
-
-
-@pytest.mark.parametrize(
-    "pruner_class,pruner_kwargs",
-    [
-        (
-            optuna.pruners.HyperbandPruner,
-            {"min_resource": 3, "max_resource": 10, "reduction_factor": 5},
-        ),
-        (
-            optuna.pruners.MedianPruner,
-            {"n_startup_trials": 8, "n_warmup_steps": 1, "interval_steps": 3},
-        ),
-        (optuna.pruners.NopPruner, {}),
-        (
-            optuna.pruners.PercentilePruner,
-            {"percentile": 50.0, "n_startup_trials": 10, "n_warmup_steps": 1, "interval_steps": 3},
-        ),
-        (
-            optuna.pruners.SuccessiveHalvingPruner,
-            {"min_resource": 3, "reduction_factor": 5, "min_early_stopping_rate": 1},
-        ),
-        (
-            optuna.pruners.ThresholdPruner,
-            {"lower": 0.0, "upper": 1.0, "n_warmup_steps": 3, "interval_steps": 2},
-        ),
-    ],
-)
-def test_allennlp_pruning_callback_with_executor(
-    pruner_class: Type[optuna.pruners.BasePruner], pruner_kwargs: Dict[str, Union[int, float]]
-) -> None:
+def test_allennlp_pruning_callback_with_executor() -> None:
     input_config_file = (
         "tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet"
     )
@@ -374,40 +323,10 @@ def test_allennlp_pruning_callback_with_executor(
         executor.run()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        pruner_name = pruner_class.__name__
-        os.mkdir(os.path.join(tmp_dir, pruner_name))
-        storage = "sqlite:///" + os.path.join(tmp_dir, pruner_name, "result.db")
-        serialization_dir = os.path.join(tmp_dir, pruner_name, "allennlp")
-
-        pruner = pruner_class(**pruner_kwargs)  # type: ignore
-        run_allennlp_executor(pruner)
-        ret_pruner = _create_pruner()
-
-        assert isinstance(ret_pruner, pruner_class)
-        for key, value in pruner_kwargs.items():
-            assert getattr(ret_pruner, "_{}".format(key)) == value
-
-
-def test_allennlp_pruning_callback_with_invalid_executor() -> None:
-    class SomeNewPruner(optuna.pruners.BasePruner):
-        def __init__(self) -> None:
-            pass
-
-        def prune(self, study: optuna.study.Study, trial: optuna.trial.FrozenTrial) -> bool:
-            return False
-
-    input_config_file = (
-        "tests/integration_tests/allennlp_tests/example_with_executor_and_pruner.jsonnet"
-    )
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
         storage = "sqlite:///" + os.path.join(tmp_dir, "result.db")
         serialization_dir = os.path.join(tmp_dir, "allennlp")
-        pruner = SomeNewPruner()
 
-        study = optuna.create_study(direction="maximize", pruner=pruner, storage=storage)
-        trial = optuna.trial.Trial(study, study._storage.create_new_trial(study._study_id))
-        trial.suggest_float("DROPOUT", 0.0, 0.5)
-
-        with pytest.raises(ValueError):
-            optuna.integration.AllenNLPExecutor(trial, input_config_file, serialization_dir)
+        pruner_mock = mock.Mock()
+        pruner_mock.prune = mock.Mock(return_value=False)
+        run_allennlp_executor(pruner_mock)
+        pruner_mock.prune.assert_called_once()


### PR DESCRIPTION
1. Implement `train_model` with `trial` object.

https://github.com/himkt/optuna/blob/4b591ed7bfdb8e99f04f58ad855c57f8065de759/optuna/integration/_allennlp.py#L60-L70

2. Invoke Optuna's `trian_model` instead of `allennlp.commands.train.train_model`.
https://github.com/himkt/optuna/blob/4b591ed7bfdb8e99f04f58ad855c57f8065de759/optuna/integration/allennlp.py#L376

3. Implement `_train_worker` with `trial` object.

https://github.com/himkt/optuna/blob/4b591ed7bfdb8e99f04f58ad855c57f8065de759/optuna/integration/_allennlp.py#L216-L230

4. Invoke Optuna's `_train_worker` instead of `allennlp.commands.train._train_worker`

https://github.com/himkt/optuna/blob/4b591ed7bfdb8e99f04f58ad855c57f8065de759/optuna/integration/_allennlp.py#L118-L126

5. [WIP] Implement `TrainModelWithOptuna`

We may have to pass `trial` to the construction of `AllenNLPPruningCallback` somehow.

https://github.com/allenai/allennlp-guide/pull/138#discussion_r475754157